### PR TITLE
Add publisher system to Gogeta

### DIFF
--- a/client/gogeta_client.go
+++ b/client/gogeta_client.go
@@ -22,8 +22,8 @@ type GogetaClient struct {
 	Storage storehouse.StoreHouse
 }
 
-// InitializeClient creates a new gogeta client
-func (client *GogetaClient) InitializeClient() {
+// Start creates a new gogeta client
+func (client *GogetaClient) Start() {
 	sess := session.Must(session.NewSession())
 
 	scm := &sourcesystem.SystemSCM{}
@@ -43,7 +43,7 @@ func (client *GogetaClient) InitializeClient() {
 
 	client.Queue = queuesystem.AmazonQueue{
 		Client: sqs.New(sess),
-		Region: os.Getenv(config.QueueRegion),
+		Region: os.Getenv(config.Region),
 		URL:    os.Getenv(config.QueueURL),
 	}
 	client.Log = log
@@ -57,7 +57,7 @@ func (client *GogetaClient) GetSourceCode() *sourcesystem.SourceRepository {
 	repo := sourcesystem.SourceRepository{}
 	messages, err := client.Queue.GetQueueMessages()
 	if err != nil {
-		client.logError(err.Error())
+		client.Log.Error(err.Error())
 	}
 
 	if len(messages) <= 0 {
@@ -73,15 +73,7 @@ func (client *GogetaClient) GetSourceCode() *sourcesystem.SourceRepository {
 	repo.ProjectName = project
 	repo.SourceOrigin = origin
 	if err := client.SCM.AddSource(&repo); err != nil {
-		client.logError(err.Error())
+		client.Log.Error(err.Error())
 	}
 	return &repo
-}
-
-func (client *GogetaClient) logError(message string) {
-	client.Log.Error(message)
-}
-
-func (client *GogetaClient) logInfo(message string) {
-	client.Log.Info(message)
 }

--- a/client/gogeta_client_test.go
+++ b/client/gogeta_client_test.go
@@ -49,7 +49,7 @@ func TestGogetaClientLogsInfo(t *testing.T) {
 	mockLog := &MockLogger{}
 
 	client.Log = mockLog
-	client.logInfo(info)
+	client.Log.Info(info)
 
 	if info != mockLog.TestData {
 		t.Errorf("Expected: %v, got: %v", info, mockLog.TestData)
@@ -62,7 +62,7 @@ func TestGogetaClientLogsErrors(t *testing.T) {
 	mockLog := &MockLogger{}
 
 	client.Log = mockLog
-	client.logError(err)
+	client.Log.Error(err)
 
 	if err != mockLog.TestData {
 		t.Errorf("Expected: %v, got: %v", err, mockLog.TestData)

--- a/main.go
+++ b/main.go
@@ -15,18 +15,18 @@ import (
 )
 
 func main() {
-	gogeta := client.GogetaClient{}
-	gogeta.InitializeClient()
+	appClient := client.GogetaClient{}
+	appClient.Start()
 
 	if os.Getenv(config.GoEnv) == "development" {
 		mockdata := `{"id":"123456","usr":"Boomer","repo":"https://github.com/Gamebuildr/Gogeta.git","proj":"Gogeta","type":"git"}`
 		mockMessages := testutils.StubbedQueueMessage(mockdata)
-		gogeta.Queue = queuesystem.AmazonQueue{
+		appClient.Queue = queuesystem.AmazonQueue{
 			Client: testutils.MockedAmazonClient{Response: mockMessages.Resp},
 			URL:    "mockUrl_%d",
 		}
 	}
-	runQueuePoll(&gogeta)
+	runQueuePoll(&appClient)
 	//gocron.Every(1).Minute().Do(runQueuePoll)
 	//startServer()
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,18 +5,16 @@ package config
 // RepoPath path to store cloned repositories
 const RepoPath = "REPO_PATH"
 
-// QueueRegion is the world region messages
-// are coming from
-const QueueRegion = "QUEUE_REGION"
+// Region is the world region messages are coming from
+const Region = "REGION"
 
 // QueueURL is the URL endpoint to recieve messages
 const QueueURL = "QUEUE_URL"
 
-// MrrobotNotifications is the endpoint to send MrRobot messages
+// MrrobotNotifications is the URL endpoint to send MrRobot messages
 const MrrobotNotifications = "MRROBOT_NOTIFICATIONS"
 
-// GamebuildrNotifications is the URL endpoint to send
-// gamebuildr messages
+// GamebuildrNotifications is the URL endpoint to send Gamebuildr messages
 const GamebuildrNotifications = "GAMEBUILDR_NOTIFICATIONS"
 
 // CodeRepoStorage is the location to save source code

--- a/pkg/gogeta/gogeta_system.go
+++ b/pkg/gogeta/gogeta_system.go
@@ -2,9 +2,9 @@ package gogeta
 
 import "github.com/Gamebuildr/Gogeta/pkg/sourcesystem"
 
-// VersionControl is the main use case for
-// interacting with the gogeta scm system
-type VersionControl interface {
+// Application is the main use case for
+// interacting with the gogeta client
+type Application interface {
 	GetSourceCode() *sourcesystem.SourceRepository
 	logError(message string)
 	logInfo(message string)

--- a/pkg/publisher/amazon_sns.go
+++ b/pkg/publisher/amazon_sns.go
@@ -1,0 +1,36 @@
+package publisher
+
+import (
+	"os"
+
+	"github.com/Gamebuildr/Gogeta/pkg/config"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sns/snsiface"
+)
+
+// AmazonNotification is the aws sns implementation of the NotificationService
+type AmazonNotification struct {
+	Session snsiface.SNSAPI
+}
+
+// Setup the function that must be run to prepare NotificationService for use
+func (service *AmazonNotification) Setup() {
+	region := os.Getenv(config.Region)
+	service.Session = sns.New(session.New(&aws.Config{Region: aws.String(region)}))
+}
+
+// PublishMessage sens a message to the Amazon queueing system
+func (service AmazonNotification) PublishMessage(msg Message) (string, error) {
+	params := &sns.PublishInput{
+		Message:  aws.String(msg.Message),
+		Subject:  aws.String(msg.Subject),
+		TopicArn: aws.String(msg.Endpoint),
+	}
+	result, err := service.Session.Publish(params)
+	if err != nil {
+		return "", err
+	}
+	return *result.MessageId, nil
+}

--- a/pkg/publisher/amazon_sns_test.go
+++ b/pkg/publisher/amazon_sns_test.go
@@ -1,0 +1,70 @@
+package publisher
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sns/snsiface"
+)
+
+type MockedAmazonClient struct {
+	snsiface.SNSAPI
+	PublishOutput sns.PublishOutput
+	Message       string
+	Subject       string
+	Endpoint      string
+}
+
+func (m *MockedAmazonClient) Publish(input *sns.PublishInput) (*sns.PublishOutput, error) {
+	messageID := "MockID"
+	output := &sns.PublishOutput{
+		MessageId: &messageID,
+	}
+	m.Message = *input.Message
+	m.Subject = *input.Subject
+	m.Endpoint = *input.TopicArn
+
+	return output, nil
+}
+
+func TestAmazonSNSClientSetupCorrectly(t *testing.T) {
+	notification := AmazonNotification{}
+	notification.Setup()
+	if notification.Session == nil {
+		t.Errorf("Amazon SNS session nil")
+	}
+}
+
+func TestAmazonSnsClientPublishesAMessage(t *testing.T) {
+	mockMessage := "Mock Message"
+	mockSubject := "Mock Subject"
+	mockEndpoint := "Mock Endpoint"
+	client := MockedAmazonClient{}
+	notification := AmazonNotification{
+		&client,
+	}
+	params := Message{
+		Message:  mockMessage,
+		Subject:  mockSubject,
+		Endpoint: mockEndpoint,
+	}
+	result, err := notification.PublishMessage(params)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if result == "" {
+		t.Errorf("Expected SNS Result Not nil")
+	}
+	if result != "MockID" {
+		t.Errorf("Expected %v, got %v", "MockID", result)
+	}
+	if client.Message != mockMessage {
+		t.Errorf("Expected %v, got %v", mockMessage, client.Message)
+	}
+	if client.Subject != mockSubject {
+		t.Errorf("Expected %v, got %v", mockSubject, client.Subject)
+	}
+	if client.Endpoint != mockEndpoint {
+		t.Errorf("Expected %v, got %v", mockEndpoint, client.Endpoint)
+	}
+}

--- a/pkg/publisher/publisher_interface.go
+++ b/pkg/publisher/publisher_interface.go
@@ -1,0 +1,14 @@
+package publisher
+
+import "github.com/Gamebuildr/gamebuildr-lumberjack/pkg/logger"
+
+// Application is the interface to specify a notification service
+type Application interface {
+	PublishMessage(msg Message) (string, error)
+}
+
+// Service is the base system for creating unique messaging services
+type Service struct {
+	Application Application
+	Log         logger.Log
+}

--- a/pkg/publisher/publisher_system.go
+++ b/pkg/publisher/publisher_system.go
@@ -1,0 +1,15 @@
+package publisher
+
+// Notifications are differnt types of messages to be sent to an endpoint
+type Notifications interface {
+	SendSimpleMessage(msg *Message)
+	SendJSON(msg *Message)
+}
+
+// Message is the data format send to endpoints
+type Message struct {
+	Message  string
+	JSON     []byte
+	Subject  string
+	Endpoint string
+}

--- a/pkg/publisher/simple_notification.go
+++ b/pkg/publisher/simple_notification.go
@@ -1,0 +1,18 @@
+package publisher
+
+// SimpleNotification is a publisher sevice that sends messages directly to a service
+type SimpleNotification Service
+
+// SendSimpleMessage sends a string message to an endpoint
+func (service SimpleNotification) SendSimpleMessage(msg *Message) {
+	service.Application.PublishMessage(*msg)
+}
+
+// SendJSON sends a strigified json object as Message to an endpoint
+func (service SimpleNotification) SendJSON(msg *Message) {
+	msg.Message = string(msg.JSON)
+	_, err := service.Application.PublishMessage(*msg)
+	if err != nil {
+		service.Log.Error(err.Error())
+	}
+}

--- a/pkg/publisher/simple_notification_test.go
+++ b/pkg/publisher/simple_notification_test.go
@@ -1,0 +1,31 @@
+package publisher
+
+import "testing"
+
+type MockPubSubApp struct{ Data string }
+
+func (app *MockPubSubApp) PublishMessage(msg Message) (string, error) {
+	app.Data = msg.Message
+	return msg.Message, nil
+}
+
+func TestSimpleNotificationSendsStringMessages(t *testing.T) {
+	application := MockPubSubApp{}
+	service := SimpleNotification{Application: &application}
+	message := Message{Message: "Mock Message"}
+	service.SendSimpleMessage(&message)
+	if application.Data != "Mock Message" {
+		t.Errorf("Expected %v, got %v", "Mock Message", application.Data)
+	}
+}
+
+func TestSimpleNotificationStringifiesJSONInput(t *testing.T) {
+	application := MockPubSubApp{}
+	service := SimpleNotification{Application: &application}
+	mockdata := []byte(`{"name":"Mock", "data":100.00}`)
+	message := Message{JSON: mockdata}
+	service.SendJSON(&message)
+	if application.Data != string(mockdata) {
+		t.Errorf("Expected %v, got %v ", `{"name":"Mock", "data":100.00}`, application.Data)
+	}
+}


### PR DESCRIPTION
- Add main publisher system

- Add 'Notification' system to separate the implementation of the pub/sub service (Amazon, Google), and the types of messages we want to send.

- Remove confusing use of Log system in the Gogeta Client