### PR TITLE
Add code generated .json file from base64 string for google credentials

### DIFF
--- a/client/gogeta_client.go
+++ b/client/gogeta_client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Gamebuildr/Gogeta/pkg/config"
+	"github.com/Gamebuildr/Gogeta/pkg/credentials"
 	"github.com/Gamebuildr/Gogeta/pkg/publisher"
 	"github.com/Gamebuildr/Gogeta/pkg/queuesystem"
 	"github.com/Gamebuildr/Gogeta/pkg/sourcesystem"
@@ -91,6 +92,13 @@ func (client *Gogeta) Start() {
 	client.Storage = store
 	client.Queue = amazonQueue
 	client.Notifications = &notifications
+
+	// Generate gcloud service .json file
+	creds := credentials.GcloudCredentials{}
+	creds.JSON = credentials.GcloudJSONCredentials{}
+	if err := creds.GenerateAccount(); err != nil {
+		client.Log.Error(err.Error())
+	}
 }
 
 // RunGogetaClient will run the complete gogeta scm system

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,7 +1,5 @@
 package config
 
-// Gogeta Environment Variables
-
 // Region is the world region messages are coming from
 const Region string = "REGION"
 
@@ -13,6 +11,13 @@ const MrrobotNotifications string = "MRROBOT_NOTIFICATIONS"
 
 // GamebuildrNotifications is the URL endpoint to send Gamebuildr messages
 const GamebuildrNotifications string = "GAMEBUILDR_NOTIFICATIONS"
+
+// GcloudServiceKey is the base64 generated key from the gcloud .json
+const GcloudServiceKey string = "GCLOUD_SERVICE_KEY"
+
+// GcloudServiceAccount is the path to the gcloud service account .json
+// The .json is automatically generated and set when the client is ran
+const GcloudServiceAccount string = "GOOGLE_APPLICATION_CREDENTIALS"
 
 // CodeRepoStorage is the location to save source code
 const CodeRepoStorage string = "CODE_REPO_STORAGE"

--- a/pkg/credentials/credential_interface.go
+++ b/pkg/credentials/credential_interface.go
@@ -1,0 +1,14 @@
+package credentials
+
+import "os"
+
+// ServiceAccount is the credentials to use with outside services
+type ServiceAccount interface {
+	GenerateAccount()
+}
+
+// JSONCredentials are credentials stored in a .json file
+type JSONCredentials interface {
+	createJSON(path string) (*os.File, error)
+	writeToJSONFile(file *os.File, key []byte) error
+}

--- a/pkg/credentials/gcloud_credentials.go
+++ b/pkg/credentials/gcloud_credentials.go
@@ -1,0 +1,68 @@
+package credentials
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+
+	"github.com/Gamebuildr/Gogeta/pkg/config"
+)
+
+// GcloudCredentials are the credentials to use with google's cloud api
+type GcloudCredentials struct {
+	JSON JSONCredentials
+}
+
+// GcloudJSONCredentials specifies the gcloud.json service account creation
+type GcloudJSONCredentials struct{}
+
+// GenerateAccount will create a new .json file from a base64 string,
+// place it at the root directory, and set the service key env variable
+func (gcloud GcloudCredentials) GenerateAccount() error {
+	rootdir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(rootdir, "/gcloud_service_account.json")
+	file, err := gcloud.JSON.createJSON(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	decodedKey, err := gcloud.decodeBase64Key()
+	if err != nil {
+		return err
+	}
+	if err = gcloud.JSON.writeToJSONFile(file, decodedKey); err != nil {
+		return err
+	}
+	os.Setenv(config.GcloudServiceAccount, path)
+	return nil
+}
+
+func (gcloud GcloudCredentials) decodeBase64Key() ([]byte, error) {
+	key := os.Getenv(config.GcloudServiceKey)
+	decodedKey, err := base64.StdEncoding.DecodeString(key)
+	if err != nil {
+		return nil, err
+	}
+	return decodedKey, nil
+}
+
+// Gcloud Credential File Helpers
+func (json GcloudJSONCredentials) createJSON(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0640)
+	if err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+func (json GcloudJSONCredentials) writeToJSONFile(file *os.File, key []byte) error {
+	_, err := file.Write(key)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/credentials/gcloud_credentials_test.go
+++ b/pkg/credentials/gcloud_credentials_test.go
@@ -1,0 +1,66 @@
+package credentials
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Gamebuildr/Gogeta/pkg/config"
+)
+
+type MockJSONCredentials struct{}
+
+func (creds MockJSONCredentials) createJSON(path string) (*os.File, error) {
+	file := os.File{}
+	return &file, nil
+}
+
+func (creds MockJSONCredentials) writeToJSONFile(file *os.File, key []byte) error {
+	return nil
+}
+
+func TestGcloudGetCredentialFileReturnsFileAtRootDirectory(t *testing.T) {
+	creds := GcloudCredentials{}
+	creds.JSON = MockJSONCredentials{}
+
+	file, err := creds.JSON.createJSON("/mock/path")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if file == nil {
+		t.Errorf("Expected JSON credential file to not be nil")
+	}
+}
+
+func TestGcloudCredentailsGeneratesCorrectBase64String(t *testing.T) {
+	expectedJSON := `{"mockkey":"mockvalue"}`
+	base64MockKey := "ewogICJtb2Nra2V5IjoibW9ja3ZhbHVlIgp9Cg=="
+	os.Setenv("GCLOUD_SERVICE_KEY", base64MockKey)
+
+	creds := GcloudCredentials{}
+	key, err := creds.decodeBase64Key()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if key == nil {
+		t.Errorf("Expected decoded key to not be nil")
+	}
+	if strings.Compare(string(key), expectedJSON) == 0 {
+		t.Errorf("Expected decoded key to be %v, but got %v", expectedJSON, key)
+	}
+}
+
+func TestGenerateAccountCreatesCoorectServiceJSON(t *testing.T) {
+	creds := GcloudCredentials{}
+	creds.JSON = MockJSONCredentials{}
+
+	if err := creds.GenerateAccount(); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	serviceAccount := os.Getenv(config.GcloudServiceAccount)
+	if serviceAccount == "" {
+		t.Errorf("Expected GCLOUD_SERVICE_ACCOUNT env variable to not be nil")
+	}
+}


### PR DESCRIPTION
- Generate a .json file from base64 string specified in env variables

- Place .json at the root of directory

- Set the GOOGLE_APPLICATION_CREDENTIALS env variable to .json path